### PR TITLE
Set game.playLink to a correct URL

### DIFF
--- a/content.json
+++ b/content.json
@@ -1,6 +1,6 @@
 {
    "game":{
-      "playLink":"https://play.coastalfreeze.me/"
+      "playLink":"https://play.coastalfreeze.net/client"
    },
    "miscellanous":{
       "aboutMessage":"Coastal Freeze Client v{{app_version}}\nCreated by Allinol and ctx for use with Coastal Freeze.\nOwners of Coastal Freeze: Fliberjig1 and Allinol",

--- a/content.json
+++ b/content.json
@@ -1,6 +1,6 @@
 {
    "game":{
-      "playLink":"https://play.coastalfreeze.net/client"
+      "playLink":"https://play.coastalfreeze.me/client"
    },
    "miscellanous":{
       "aboutMessage":"Coastal Freeze Client v{{app_version}}\nCreated by Allinol and ctx for use with Coastal Freeze.\nOwners of Coastal Freeze: Fliberjig1 and Allinol",


### PR DESCRIPTION
A while ago I changed it to `play.coastalfreeze.me` because `/client` seemed broken. Since then it was fixed, but as this config line was not actually used in client it was never updated. This PR reverts commit a599117 and updates the domain to use `coastalfreeze.me` instead of `coastalfreeze.net`.

No, I don't know why I wrote such a long PR message. Anyway, here is a poem I like:

# **The Road Not Taken** - Robert Frost
```
Two roads diverged in a yellow wood,
And sorry I could not travel both
And be one traveler, long I stood
And looked down one as far as I could
To where it bent in the undergrowth;

Then took the other, as just as fair,
And having perhaps the better claim,
Because it was grassy and wanted wear;
Though as for that the passing there
Had worn them really about the same,

And both that morning equally lay
In leaves no step had trodden black.
Oh, I kept the first for another day!
Yet knowing how way leads on to way,
I doubted if I should ever come back.

I shall be telling this with a sigh
Somewhere ages and ages hence:
Two roads diverged in a wood, and I—
I took the one less traveled by,
And that has made all the difference.
```